### PR TITLE
Prefer glue_data() when data might be list-ish, not an actual environment

### DIFF
--- a/R/convert.r
+++ b/R/convert.r
@@ -34,7 +34,7 @@ convert_http_to_at <- function(link,
       http_info$repo <- resolve_handle(http_info$repo, .token = .token)
     }
 
-    glue::glue("at://{repo}/{collection}/{rkey}", .envir = http_info)
+    glue::glue_data(http_info, "at://{repo}/{collection}/{rkey}")
 
   })
 
@@ -57,4 +57,3 @@ convert_at_to_http <- function(link) {
 
   })
 }
-


### PR DESCRIPTION
This PR is inspired by doing revdep checks for glue. The soon-to-be-released `glue::glue()` will error when `.envir` is not an actual environment. `.envir` has always been documented to be an environment and I've been working to make that actually true.

`glue_data()` *does* officially accept something "list-ish" as `.x`. So it is a better choice for your usage.

Backstory in glue:

https://github.com/tidyverse/glue/issues/308
https://github.com/tidyverse/glue/commit/e2b74ff17704261b5a7da25b4ebd2dec94740764
https://github.com/tidyverse/glue/issues/341