### PR TITLE
Fix for dev httr2

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -59,6 +59,7 @@ make_request <- function(hostname, params, req_method = c("GET", "POST")) {
       hostname = hostname,
       query = as.list(all_params)
     ) |>
+      structure(class = "httr2_url") |>
       httr2::url_build() |>
       httr2::request() |>
       httr2::req_method("GET") |>


### PR DESCRIPTION
httr2 has a stricter URL builder, so I've made the minimal fix to get your code working again.

The proposed code should work with both old and new httr2, so you can submit to CRAN now, if you want. I am planning to submit httr2 to CRAN on Jan 17, so you'll have to submit ~2 weeks after this date.