### PR TITLE
Allow multiple images per post when using post_thread

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,11 @@ Authors@R:
              family = "Votta", 
              email = "fabio.votta@gmail.com", 
              role = c("aut", "ctb"),
-             comment = c(ORCID = "0000-0002-3143-5942")))
+             comment = c(ORCID = "0000-0002-3143-5942")),
+      person(given = "Nicholas",
+             family = "Erskine",
+             email = "nicholas.erskine95@gmail.com",
+             role = c("ctb")))
 Description: Wraps the 'AT' Protocol (Authenticated Transfer Protocol) behind 
     'Bluesky' <https://bsky.social>. Functions can be used for, among others, 
     retrieving posts and followers from the network or posting content.

--- a/R/feed.r
+++ b/R/feed.r
@@ -889,9 +889,9 @@ post_thread <- function(texts,
   for (i in seq_along(thread_df$text)) {
     ref <- do.call(
       what = post_skeet,
-      args = list(text = thread_df$text[i],
-                  image = thread_df$image[i],
-                  image_alt = thread_df$image_alt[i],
+      args = list(text = thread_df$text[[i]],
+                  image = thread_df$image[[i]],
+                  image_alt = thread_df$image_alt[[i]],
                   in_reply_to = ref)
     )
     refs <- rbind(refs, as.data.frame(ref))

--- a/R/feed.r
+++ b/R/feed.r
@@ -876,7 +876,7 @@ post_thread <- function(texts,
       cli::cli_abort("texts, images, image_alts must all have the same length or be NULL.")
     }
 
-    thread_df <- data.frame(
+    thread_df <- tibble(
       text = texts,
       image = images,
       image_alt = image_alts

--- a/R/feed.r
+++ b/R/feed.r
@@ -876,7 +876,7 @@ post_thread <- function(texts,
       cli::cli_abort("texts, images, image_alts must all have the same length or be NULL.")
     }
 
-    thread_df <- tibble(
+    thread_df <- tibble::tibble(
       text = texts,
       image = images,
       image_alt = image_alts

--- a/R/feed.r
+++ b/R/feed.r
@@ -736,7 +736,7 @@ post <- function(text,
   }
 
   if (!is.null(image) && !identical(image, "")) {
-    image <- from_ggplot(image)
+    image <- purrr::map_chr(image, from_ggplot)
     rlang::check_installed("magick")
     image_alt[utils::tail(length(image_alt):length(image), -1)] <- ""
     images <- purrr::map2(image, image_alt, function(i, alt) {

--- a/R/feed.r
+++ b/R/feed.r
@@ -845,8 +845,8 @@ delete_post <- delete_skeet
 #' Post a thread
 #'
 #' @param texts a vector of skeet (post) texts
-#' @param images paths to images to be included in each post
-#' @param image_alts alt texts for the images to be included in each post
+#' @param images paths to images to be included in each post. This may be a character vector, or a list of character vectors if multiple images per post are required.
+#' @param image_alts alt texts for the images to be included in each post. If images is a list of character vectors, this should also be a list of character vectors and have the same shape.
 #' @param thread_df instead of defining texts, images and image_alts, you can
 #'   also create a data frame with the information in columns of the same names.
 #' @inheritParams search_user

--- a/R/feed.r
+++ b/R/feed.r
@@ -871,7 +871,7 @@ post_thread <- function(texts,
 
   if (is.null(thread_df)) {
     images <- images  %||% rep("", length(texts))
-    image_alts <- image_alts  %||% rep("", length(texts))
+    image_alts <- image_alts  %||% lapply(images, \(x)rep("",length(x)))
     if (length(unique(lengths(list(texts, images, image_alts)))) != 1L) {
       cli::cli_abort("texts, images, image_alts must all have the same length or be NULL.")
     }

--- a/man/atrrr-package.Rd
+++ b/man/atrrr-package.Rd
@@ -27,6 +27,7 @@ Authors:
 \itemize{
   \item Benjamin Guinaudeau \email{benjamin.guinaudeau@uni-konstanz.de} (\href{https://orcid.org/0000-0001-7206-6875}{ORCID}) [contributor]
   \item Fabio Votta \email{fabio.votta@gmail.com} (\href{https://orcid.org/0000-0002-3143-5942}{ORCID}) [contributor]
+  \item Nicholas Erskine \email{nicholas.erskine95@gmail.com} [contributor]
 }
 
 }

--- a/man/post_thread.Rd
+++ b/man/post_thread.Rd
@@ -16,9 +16,9 @@ post_thread(
 \arguments{
 \item{texts}{a vector of skeet (post) texts}
 
-\item{images}{paths to images to be included in each post}
+\item{images}{paths to images to be included in each post. This may be a character vector, or a list of character vectors if multiple images per post are required.}
 
-\item{image_alts}{alt texts for the images to be included in each post}
+\item{image_alts}{alt texts for the images to be included in each post. If images is a list of character vectors, this should also be a list of character vectors and have the same shape.}
 
 \item{thread_df}{instead of defining texts, images and image_alts, you can
 also create a data frame with the information in columns of the same names.}


### PR DESCRIPTION
When using `post_thread` it would be useful to be able to include multiple images per post in a similar way to how this is already possible when using `post` or `post_skeet` directly. The natural way to support this is by having the user provide a list of character vectors of image paths, with one character vector per post. 

Currently this fails because if a list is provided to post_thread, the function passes a list of length one containing the character vector to `post`, but `post` expects non-nested input. The code change required to fix this is very simple - just a matter of using `[[` instead of `[` when selecting the image and image_alt for each post.